### PR TITLE
Release 0.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mousehole",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "type": "module",
   "private": true,
   "main": "src/index.tsx",


### PR DESCRIPTION
Release 0.2.1. Tagged on Docker Hub as [`tmmrtn/mousehole:pr-26`](https://hub.docker.com/layers/tmmrtn/mousehole/pr-26)

@Mlitz Thanks for your help this cycle! I know you've worked around your dying-container issue with a restart policy, but would you be willing to run this image in your setup? If you run it for a day or so, maybe we can see if the updated dependencies and bun runtime have improved your situation. 🤞

If you have any other comments, let me know!

I'd like to release this by the end of the week.