### PR TITLE
Add support for Bun HTTP proxy configuration in fetch requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Add Bun `proxy()` param to handle HTTP proxy environments in [#57](https://github.com/t-mart/mousehole/pull/57)
 - State updates to `PUT /state` now save correctly (was writing Promise object
   instead of actual data) in [#42](https://github.com/t-mart/mousehole/pull/42)
 - State directory is now created automatically on first write if it doesn't

--- a/README.md
+++ b/README.md
@@ -160,6 +160,9 @@ Choose `latest` if you do not know which to pick.
   Mousehole is still talking with MAM at some regular interval and is detecting
   out-of-band changes to the cookie.
 - `TZ`: _(Default `Etc/UTC`)_ The timezone for displaying localized times.
+- `HTTPS_PROXY` / `HTTP_PROXY`: _(Default `undefined`)_ The HTTP proxy URL to
+  use for outbound requests (e.g. `http://gluetun:8888`). `HTTPS_PROXY` takes
+  precedence over `HTTP_PROXY`.
 
 ## Contributing
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mousehole",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "type": "module",
   "private": true,
   "main": "src/index.tsx",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mousehole",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "type": "module",
   "private": true,
   "main": "src/index.tsx",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mousehole",
-  "version": "0.2.2",
+  "version": "0.2.1",
   "type": "module",
   "private": true,
   "main": "src/index.tsx",

--- a/src/backend/config.ts
+++ b/src/backend/config.ts
@@ -69,4 +69,12 @@ export const config = {
   port: environmentOrFallback("MOUSEHOLE_PORT", 5010, (value) =>
     Number.parseInt(value)
   ),
+
+  /**
+   * The HTTP proxy URL to use for outbound fetch requests.
+   *
+   * Reads HTTPS_PROXY, falling back to HTTP_PROXY. Undefined when neither is
+   * set.
+   */
+  proxy: environmentOrFallback("HTTPS_PROXY", process.env.HTTP_PROXY),
 };

--- a/src/backend/external-api/host-info.ts
+++ b/src/backend/external-api/host-info.ts
@@ -7,12 +7,7 @@ const endpointUrl = new URL("https://t.myanonamouse.net/json/jsonIp.php");
 
 export async function getHostInfo() {
   const fetchInit: RequestInit & { proxy?: string } = {
-    headers: {
-      "User-Agent": config.userAgent,
-      // Avoid Bun reusing a stale keep-alive connection through the proxy,
-      // which surfaces as InvalidHTTPResponse.
-      Connection: "close",
-    },
+    headers: { "User-Agent": config.userAgent },
     proxy: config.proxy,
   };
   const response = await fetch(endpointUrl, fetchInit);

--- a/src/backend/external-api/host-info.ts
+++ b/src/backend/external-api/host-info.ts
@@ -7,7 +7,12 @@ const endpointUrl = new URL("https://t.myanonamouse.net/json/jsonIp.php");
 
 export async function getHostInfo() {
   const fetchInit: RequestInit & { proxy?: string } = {
-    headers: { "User-Agent": config.userAgent },
+    headers: {
+      "User-Agent": config.userAgent,
+      // Avoid Bun reusing a stale keep-alive connection through the proxy,
+      // which surfaces as InvalidHTTPResponse.
+      Connection: "close",
+    },
     proxy: config.proxy,
   };
   const response = await fetch(endpointUrl, fetchInit);

--- a/src/backend/external-api/host-info.ts
+++ b/src/backend/external-api/host-info.ts
@@ -6,11 +6,11 @@ import { ipResponseBodySchema } from "#backend/types.ts";
 const endpointUrl = new URL("https://t.myanonamouse.net/json/jsonIp.php");
 
 export async function getHostInfo() {
-  const response = await fetch(endpointUrl, {
-    headers: {
-      "User-Agent": config.userAgent,
-    },
-  });
+  const fetchInit: RequestInit & { proxy?: string } = {
+    headers: { "User-Agent": config.userAgent },
+    proxy: config.proxy,
+  };
+  const response = await fetch(endpointUrl, fetchInit);
 
   if (!response.ok) {
     throw new Error(

--- a/src/backend/external-api/mam.ts
+++ b/src/backend/external-api/mam.ts
@@ -28,6 +28,10 @@ export async function updateMamIp(
 
     // must supply cookie
     Cookie: cookie.cookieString(),
+
+    // Avoid Bun reusing a stale keep-alive connection through the proxy,
+    // which surfaces as InvalidHTTPResponse.
+    Connection: "close",
   };
 
   const performedAt = getNowZdt();

--- a/src/backend/external-api/mam.ts
+++ b/src/backend/external-api/mam.ts
@@ -33,9 +33,11 @@ export async function updateMamIp(
   const performedAt = getNowZdt();
 
   // Note: the IP address is determined by the server from the request.
-  const response = await fetch(endpointUrl, {
+  const fetchInit: RequestInit & { proxy?: string } = {
     headers,
-  });
+    proxy: config.proxy,
+  };
+  const response = await fetch(endpointUrl, fetchInit);
 
   const json = await parseJsonResponse(response);
   const { data: body, error: parseError } =

--- a/src/backend/external-api/mam.ts
+++ b/src/backend/external-api/mam.ts
@@ -28,10 +28,6 @@ export async function updateMamIp(
 
     // must supply cookie
     Cookie: cookie.cookieString(),
-
-    // Avoid Bun reusing a stale keep-alive connection through the proxy,
-    // which surfaces as InvalidHTTPResponse.
-    Connection: "close",
   };
 
   const performedAt = getNowZdt();


### PR DESCRIPTION
Bun's `fetch()` supports a `proxy` option but does not automatically read the
standard `HTTP_PROXY` / `HTTPS_PROXY` environment variables. This PR wires them
up explicitly so Mousehole works when deployed behind a VPN-based egress proxy
(e.g. gluetun in Kubernetes).

### Changes

- **`config.ts`** — adds a `proxy` field that reads `HTTPS_PROXY`, falling back
  to `HTTP_PROXY`, using the existing `environmentOrFallback` helper. `undefined`
  when neither is set.
- **`mam.ts` / `host-info.ts`** — passes `config.proxy` to every outbound
  `fetch()` call via a typed `fetchInit` variable
  (`RequestInit & { proxy?: string }`) to satisfy TypeScript's excess property
  check against Bun's not-yet-typed runtime option.
- **`README.md`** — documents the two environment variables.

### Notes

No behaviour change for existing users — Bun silently ignores `proxy: undefined`,
so deployments without these env vars are unaffected.
